### PR TITLE
chore: remove unsupported runtimes

### DIFF
--- a/src/lambda-powertools-layer.ts
+++ b/src/lambda-powertools-layer.ts
@@ -128,7 +128,6 @@ function getRuntimesFromRuntimeFamily(
   switch (runtimeFamily) {
     case lambda.RuntimeFamily.PYTHON:
       return [
-        lambda.Runtime.PYTHON_3_7,
         lambda.Runtime.PYTHON_3_8,
         lambda.Runtime.PYTHON_3_9,
         lambda.Runtime.PYTHON_3_10,
@@ -137,8 +136,6 @@ function getRuntimesFromRuntimeFamily(
       ];
     case lambda.RuntimeFamily.NODEJS:
       return [
-        lambda.Runtime.NODEJS_12_X,
-        lambda.Runtime.NODEJS_14_X,
         lambda.Runtime.NODEJS_16_X,
         lambda.Runtime.NODEJS_18_X,
         lambda.Runtime.NODEJS_20_X,

--- a/test/lambda-powertools-python-layer.test.ts
+++ b/test/lambda-powertools-python-layer.test.ts
@@ -22,7 +22,6 @@ describe('with no configuration the construct', () => {
   test('matches the python 3.x runtimes', () => {
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
       CompatibleRuntimes: [
-        'python3.7',
         'python3.8',
         'python3.9',
         'python3.10',

--- a/test/lambda-powertools-typescript-layer.test.ts
+++ b/test/lambda-powertools-typescript-layer.test.ts
@@ -25,8 +25,6 @@ describe('with minimal configuration the construct', () => {
   test('matches the nodejs runtimes', () => {
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
       CompatibleRuntimes: [
-        'nodejs12.x',
-        'nodejs14.x',
         'nodejs16.x',
         'nodejs18.x',
         'nodejs20.x',


### PR DESCRIPTION
This PR removes unsupported runtimes `node12`, `node14`, and `python3.7`.

Fixes #84 