### PR TITLE
chore(ci): bump jsii container image to node 20

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -33,7 +33,7 @@ jobs:
           name: .repo.patch
           path: .repo.patch
     container:
-      image: jsii/superchain:1-buster-slim-node16
+      image: public.ecr.aws/jsii/superchain:1-bullseye-slim-node20
   pr:
     name: Create Pull Request
     needs: upgrade


### PR DESCRIPTION
Bumping jsii super chain image to node20 according to the [docs](https://github.com/aws/jsii/blob/main/superchain/README.md#image-tags).
 
Fixes #89 