### PR TITLE
chore(layer): add Python version in Layer description

### DIFF
--- a/src/lambda-powertools-layer-python-v3.ts
+++ b/src/lambda-powertools-layer-python-v3.ts
@@ -68,7 +68,7 @@ export class LambdaPowertoolsLayerPythonV3 extends lambda.LayerVersion {
           ),
           PYTHON_VERSION: pythonVersionNormalized,
         },
-        // supports cross-platform docker build
+        // supports cross-platform docker build using different Python versions
         platform: getDockerPlatformNameFromArchitectures(
           compatibleArchitectures,
         ),

--- a/src/lambda-powertools-layer-python-v3.ts
+++ b/src/lambda-powertools-layer-python-v3.ts
@@ -77,7 +77,7 @@ export class LambdaPowertoolsLayerPythonV3 extends lambda.LayerVersion {
       license: 'MIT-0',
       compatibleRuntimes: [props?.pythonVersion || Runtime.PYTHON_3_12],
       description:
-        `Powertools for AWS Lambda (Python) V3 [${compatibleArchitecturesDescription}]${props?.includeExtras ? ' with extra dependencies' : ''
+        `Powertools for AWS Lambda (Python) V3 [${compatibleArchitecturesDescription} - Python ${pythonVersionNormalized}]${props?.includeExtras ? ' with extra dependencies' : ''
         } ${props?.version ? `version ${props?.version}` : 'latest version'
         }`.trim(),
       // Dear reader: I'm happy that you've stumbled upon this line too! You might wonder, why are we doing this and passing `undefined` when the list is empty?

--- a/test/lambda-powertools-python-layer-v3.test.ts
+++ b/test/lambda-powertools-python-layer-v3.test.ts
@@ -3,13 +3,15 @@ import { Template } from 'aws-cdk-lib/assertions';
 import { Architecture, Runtime, RuntimeFamily } from 'aws-cdk-lib/aws-lambda';
 import { LambdaPowertoolsLayerPythonV3, constructBuildArgs } from '../src';
 
+const defaultPythonVersion = 'Python 3.12';
+
 describe('with no configuration the construct', () => {
   const stack = new Stack();
   new LambdaPowertoolsLayerPythonV3(stack, 'PowertoolsLayerPythonV3');
   const template = Template.fromStack(stack);
   test('synthesizes successfully', () => {
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Powertools for AWS Lambda (Python) V3 [x86_64] latest version',
+      Description: `Powertools for AWS Lambda (Python) V3 [x86_64 - ${defaultPythonVersion}] latest version`,
     });
   });
 
@@ -106,7 +108,7 @@ describe('with arm64 architecture', () => {
   const template = Template.fromStack(stack);
   test('synthesizes successfully', () => {
     template.hasResourceProperties('AWS::Lambda::LayerVersion', {
-      Description: 'Powertools for AWS Lambda (Python) V3 [arm64] latest version',
+      Description: `Powertools for AWS Lambda (Python) V3 [arm64 - ${defaultPythonVersion}] latest version`,
       CompatibleArchitectures: ['arm64'],
     });
   });
@@ -156,7 +158,7 @@ describe('with version configuration the construct', () => {
       'AWS::Lambda::LayerVersion',
       {
         Description:
-          'Powertools for AWS Lambda (Python) V3 [x86_64] version 1.21.0',
+        `Powertools for AWS Lambda (Python) V3 [x86_64 - ${defaultPythonVersion}] version 1.21.0`,
       },
     );
   });
@@ -184,7 +186,7 @@ describe('with version configuration the construct', () => {
       'AWS::Lambda::LayerVersion',
       {
         Description:
-          'Powertools for AWS Lambda (Python) V3 [x86_64] with extra dependencies version 2.40.0',
+          `Powertools for AWS Lambda (Python) V3 [x86_64 - ${defaultPythonVersion}] with extra dependencies version 2.40.0`,
       },
     );
   });
@@ -200,7 +202,7 @@ describe('with version configuration the construct', () => {
       'AWS::Lambda::LayerVersion',
       {
         Description:
-          'Powertools for AWS Lambda (Python) V3 [x86_64] with extra dependencies latest version',
+          `Powertools for AWS Lambda (Python) V3 [x86_64 - ${defaultPythonVersion}] with extra dependencies latest version`,
       },
     );
   });


### PR DESCRIPTION
Fixes #107 

Currently the Python layer description is something like Powertools for AWS Lambda (Python) V3 [x86_64] with extra dependencies version 1.0.1 and Powertools for AWS Lambda (Python) V3 [arm64] with extra dependencies version 1.0.1, we have not added information about which Python version this respective layer is. We need to add this for better visibility for customers.

New description:

Powertools for AWS Lambda (Python) V3 [x86_64 - Python xx] ....

Powertools for AWS Lambda (Python) V3 [arm64 - Python xx] ...